### PR TITLE
[BREAKING] Using Hashes instead of Strings to store runtime keys

### DIFF
--- a/lib/resque/unique_at_runtime/configuration.rb
+++ b/lib/resque/unique_at_runtime/configuration.rb
@@ -50,7 +50,7 @@ module Resque
 
       def debug_mode_from_env
         env_debug = ENV['RESQUE_DEBUG']
-        @debug_mode = !!(env_debug == 'true' || (env_debug.is_a?(String) && env_debug.match?(/runtime/)))
+        @debug_mode = !!(env_debug == 'true' || (env_debug.is_a?(String) && env_debug.match(/runtime/)))
       end
     end
   end


### PR DESCRIPTION
* What type of change is this?

  - Improvement

* Why is this change necessary?

  - It's slow to scan and delete all keys stored as Strings

* How does it address the issue?

  - Grouping unique keys inside a Hash allows the deletion of all tuples
  with an O(1) cost

* What side effects does this change have?

  - Old keys may be left in Redis if aren't deleted during the upgrade

* Links (Jira, Confluence, etc)?

  - http://redis.io/commands/hsetnx